### PR TITLE
Fix emoji picker not appearing when replying to status with content warning

### DIFF
--- a/Views/UIKit/CompositionView.swift
+++ b/Views/UIKit/CompositionView.swift
@@ -96,7 +96,7 @@ private extension CompositionView {
         spoilerTextField.placeholder = NSLocalizedString("status.spoiler-text-placeholder", comment: "")
         spoilerTextField.inputAccessoryView = spoilerTextinputAccessoryView
         spoilerTextField.tag = spoilerTextinputAccessoryView.tagForInputView
-        spoilerTextField.isHidden_stackViewSafe = true
+        spoilerTextField.isHidden_stackViewSafe = !viewModel.displayContentWarning
         spoilerTextField.addAction(
             UIAction { [weak self] _ in self?.spoilerTextFieldEditingChanged() },
             for: .editingChanged)


### PR DESCRIPTION
### Summary

Fixes #14

- [X] I have signed [Metabolist's Contributor License Agreement](https://metabolist.org/cla)
