### PR TITLE
Show reblog count and favorite count for a post

### DIFF
--- a/Views/UIKit/Content Views/StatusView.swift
+++ b/Views/UIKit/Content Views/StatusView.swift
@@ -630,10 +630,12 @@ private extension StatusView {
         }
 
         setReblogButtonColor(reblogged: viewModel.reblogged)
+        reblogButton.setCountTitle(count: viewModel.reblogsCount, isContextParent: isContextParent)
         reblogButton.isEnabled = viewModel.canBeReblogged && isAuthenticated
         reblogButton.menu = authenticatedIdentitiesMenu { viewModel.toggleReblogged(identityId: $0.id) }
 
         setFavoriteButtonColor(favorited: viewModel.favorited)
+        favoriteButton.setCountTitle(count: viewModel.favoritesCount, isContextParent: isContextParent)
         favoriteButton.isEnabled = isAuthenticated
         favoriteButton.menu = authenticatedIdentitiesMenu { viewModel.toggleFavorited(identityId: $0.id) }
 


### PR DESCRIPTION
### Summary

Until now, only the number of comments are shown for a post. Now, the number of reblogs and favorites is displayed as well.

### Other Information

Screenshot of an example post:
<img width="390" alt="Bildschirm­foto 2022-11-01 um 09 26 42" src="https://user-images.githubusercontent.com/38211057/199190856-83cd19ba-efb8-43d0-b36c-72543bd5c155.png">

Thanks for contributing to Metatext! -->

- [x] I have signed [Metabolist's Contributor License Agreement](https://metabolist.org/cla)
