### PR TITLE
Fix sending empty search query to Mastodon API

### DIFF
--- a/ServiceLayer/Sources/ServiceLayer/Services/SearchService.swift
+++ b/ServiceLayer/Sources/ServiceLayer/Services/SearchService.swift
@@ -36,6 +36,10 @@ extension SearchService: CollectionService {
     public func request(maxId: String?, minId: String?, search: Search?) -> AnyPublisher<Never, Error> {
         guard let search = search else { return Empty().eraseToAnyPublisher() }
 
+        if (search.query.trimmingCharacters(in: .whitespaces).isEmpty){
+            return Empty().eraseToAnyPublisher()
+        }
+        
         return mastodonAPIClient.request(ResultsEndpoint.search(search))
             .flatMap { results in contentDatabase.insert(results: results).collect().map { _ in results } }
             .handleEvents(receiveOutput: { resultsSubject.send(($0, search)) })


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Fixes #96 - We no longer send an empty query to the Mastodon API. In addition, the query ignores leading and trailing whitespace.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.

Thanks for contributing to Metatext! -->

- [x] I have signed [Metabolist's Contributor License Agreement](https://metabolist.org/cla)
