### PR TITLE
Increase Search Debounce to 800ms

### DIFF
--- a/ViewModels/Sources/ViewModels/View Models/SearchViewModel.swift
+++ b/ViewModels/Sources/ViewModels/View Models/SearchViewModel.swift
@@ -41,7 +41,7 @@ public final class SearchViewModel: CollectionItemsViewModel {
 }
 
 private extension SearchViewModel {
-    static let debounceInterval: TimeInterval = 0.2
+    static let debounceInterval: TimeInterval = 0.8
 }
 
 private extension SearchScope {


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

**Issue**

With the current debounce timeout, searches are often executed while the user is still typing / copy pasting something from the clipboard. This often leads to the depicted alert being shown and completely interrupts the user when typing. I've tried to look up some accounts from other instances and this issue is a deal-breaker for doing so.

**Solution**

Increase debounce for search queries to 800ms, previously with 200ms debounce deli effectively every keystroke on the keyboard let to a search query. When looking up usernames on other instance this lead to a really bad UX (please see gif). 

Especially when correcting the text because of typos or copy paste errors.

With the increased delay the search queries are less frequent, yet frequent enough to provide a smooth search experience, in general I'd say the search UX has improved drastically.

| Preview | Description |
|---|---|
| ![RPReplay_Final1667768355 mp4](https://user-images.githubusercontent.com/126418/200195489-764a38c8-7472-437e-9f83-998e437c9adc.gif) | With the increased delay the search queries are less frequent, yet frequent enough to provide a smooth search experience, in general I'd say the search UX has improved drastically. |

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.

Thanks for contributing to Metatext! -->

- [x] I have signed [Metabolist's Contributor License Agreement](https://metabolist.org/cla)
