### PR TITLE
hide link previews when a status is hidden behind a content warning (fixes issue #95)

### DIFF
--- a/Views/UIKit/StatusBodyView.swift
+++ b/Views/UIKit/StatusBodyView.swift
@@ -59,7 +59,7 @@ final class StatusBodyView: UIView {
             pollView.isAccessibilityElement = !isContextParent || viewModel.hasVotedInPoll || viewModel.isPollExpired
 
             cardView.viewModel = viewModel.cardViewModel
-            cardView.isHidden = viewModel.cardViewModel == nil
+            cardView.isHidden = viewModel.cardViewModel == nil || !viewModel.shouldShowContent
 
             accessibilityAttributedLabel = accessibilityAttributedLabel(forceShowContent: false)
 


### PR DESCRIPTION
### Summary

hi! this seemed like an extremely easy fix, so i thought i'd give it a shot 😅 i hope i didn't miss anything lol!

screenshots of what the fix looks like:

<img width="318" alt="screenshot of a post by @dog, with a content warning reading 'woof woof!' and a 'show more' button" src="https://user-images.githubusercontent.com/4295016/200565406-d10ca051-b686-4e46-9fa5-cd49b6cb3c06.png">
<img width="320" alt="screenshot of the same post as the previous image, but the button now says 'show less', and the post's body is now shown: both the text reading 'arwoo!' and the link preview card to the wikipedia article for Dog" src="https://user-images.githubusercontent.com/4295016/200565416-c895f020-3858-406c-bf7e-8e4cefd58d72.png">

fixes issue #95

### Other Information

- [x] I have signed [Metabolist's Contributor License Agreement](https://metabolist.org/cla)
