### PR TITLE
new feature added: option to prepend "re: " to content warnings when replying

### DIFF
--- a/Localizations/en.lproj/Localizable.strings
+++ b/Localizations/en.lproj/Localizable.strings
@@ -248,6 +248,7 @@
 "preferences.require-double-tap-to-favorite" = "Require double tap to favorite";
 "preferences.show-reblog-and-favorite-counts" = "Show boost and favorite counts";
 "preferences.status-word" = "Status word";
+"preferences.add-reply-prefix-cw" = "Prepend \"re: \" to content warnings when replying";
 "filters.active" = "Active";
 "filters.expired" = "Expired";
 "filter.add-new" = "Add New Filter";

--- a/Localizations/es.lproj/Localizable.strings
+++ b/Localizations/es.lproj/Localizable.strings
@@ -248,6 +248,7 @@
 "preferences.require-double-tap-to-favorite" = "Doble tap para añadir a favoritos";
 "preferences.show-reblog-and-favorite-counts" = "Mostrar boost y cuentas favoritas";
 "preferences.status-word" = "Palabra de estado";
+"preferences.add-reply-prefix-cw" = "Anteponer \"re: \" a las advertencias de contenido al responder";
 "filters.active" = "Activo";
 "filters.expired" = "Ha caducado";
 "filter.add-new" = "Añadir un filtro nuevo";

--- a/Localizations/ja.lproj/Localizable.strings
+++ b/Localizations/ja.lproj/Localizable.strings
@@ -248,6 +248,7 @@
 "preferences.require-double-tap-to-favorite" = "ダブルタップでお気に入り";
 "preferences.show-reblog-and-favorite-counts" = "ブースト・お気に入り数を表示";
 "preferences.status-word" = "ステータスを表す言葉";
+"preferences.add-reply-prefix-cw" = "返信するとき警告に \"re: \"を付加する";
 "filters.active" = "有効";
 "filters.expired" = "期限切れ";
 "filter.add-new" = "新しいフィルターを追加";

--- a/Localizations/ko.lproj/Localizable.strings
+++ b/Localizations/ko.lproj/Localizable.strings
@@ -248,6 +248,7 @@
 "preferences.require-double-tap-to-favorite" = "두 번 탭 해서 즐겨찾기";
 "preferences.show-reblog-and-favorite-counts" = "부스트 및 즐겨찾기 수 표시";
 "preferences.status-word" = "상태를 나타내는 말";
+"preferences.add-reply-prefix-cw" = "열람주의가 달린 글에 답장을 할 때 열람주의 문구 앞에 “re: ”를 추가합니다";
 "filters.active" = "활성화";
 "filters.expired" = "만료된 필터";
 "filter.add-new" = "새 필터 추가";

--- a/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/Localizations/zh-Hans.lproj/Localizable.strings
@@ -248,6 +248,7 @@
 "preferences.require-double-tap-to-favorite" = "需要双击才能点赞";
 "preferences.show-reblog-and-favorite-counts" = "显示转发与点赞的计数";
 "preferences.status-word" = "表述状态用的词";
+"preferences.add-reply-prefix-cw" = "回复时在内容警告前加上“re:”";
 "filters.active" = "已启用";
 "filters.expired" = "已过期";
 "filter.add-new" = "添加新筛选器";

--- a/ServiceLayer/Sources/ServiceLayer/Utilities/AppPreferences.swift
+++ b/ServiceLayer/Sources/ServiceLayer/Utilities/AppPreferences.swift
@@ -181,6 +181,11 @@ public extension AppPreferences {
         get { self[.useUniversalLinks] ?? true }
         set { self[.useUniversalLinks] = newValue }
     }
+
+    var addReplyPrefixToContentWarning: Bool {
+        get { self[.addReplyPrefixToContentWarning] ?? false }
+        set { self[.addReplyPrefixToContentWarning] = newValue }
+    }
 }
 
 private extension AppPreferences {
@@ -202,6 +207,7 @@ private extension AppPreferences {
         case notificationSounds
         case openLinksInDefaultBrowser
         case useUniversalLinks
+        case addReplyPrefixToContentWarning
     }
 
     subscript<T>(index: Item) -> T? {

--- a/ViewModels/Sources/ViewModels/View Models/NewStatusViewModel.swift
+++ b/ViewModels/Sources/ViewModels/View Models/NewStatusViewModel.swift
@@ -22,6 +22,8 @@ public final class NewStatusViewModel: ObservableObject {
     private let compositionEventsSubject = PassthroughSubject<CompositionViewModel.Event, Never>()
     private var cancellables = Set<AnyCancellable>()
 
+    private let REPLY_CONTENT_WARNING_PREFIX = "re: "
+
     // swiftlint:disable:next function_body_length
     public init(allIdentitiesService: AllIdentitiesService,
                 identityContext: IdentityContext,
@@ -83,8 +85,17 @@ public final class NewStatusViewModel: ObservableObject {
                 compositionViewModel.text = mentions.joined(separator: " ").appending(" ")
             }
 
-            compositionViewModel.contentWarning = inReplyTo.spoilerText
-            compositionViewModel.displayContentWarning = !inReplyTo.spoilerText.isEmpty
+            let contentWarning = inReplyTo.spoilerText
+            let hasContentWarning = !contentWarning.isEmpty
+
+            let needsPrefix =
+                hasContentWarning
+                && identityContext.appPreferences.addReplyPrefixToContentWarning
+                && !contentWarning.hasPrefix(REPLY_CONTENT_WARNING_PREFIX)
+            let prefix = needsPrefix ? REPLY_CONTENT_WARNING_PREFIX : ""
+
+            compositionViewModel.displayContentWarning = hasContentWarning
+            compositionViewModel.contentWarning = prefix + contentWarning
         } else if let directMessageTo = directMessageTo {
             compositionViewModel.text = directMessageTo.accountName.appending(" ")
             visibility = .direct

--- a/Views/SwiftUI/PreferencesView.swift
+++ b/Views/SwiftUI/PreferencesView.swift
@@ -142,6 +142,8 @@ struct PreferencesView: View {
                         }
                     }
                 }
+                Toggle("preferences.add-reply-prefix-cw",
+                       isOn: $identityContext.appPreferences.addReplyPrefixToContentWarning)
             }
         }
         .navigationTitle("preferences")


### PR DESCRIPTION
### Summary

hi again!

this is a slightly bigger pr than my previous one-liner :)

i really like this feature that [glitch-soc](https://github.com/glitch-soc/mastodon/) has, and it felt simple enough for me to be able to jump into the code and implement it

i added a new setting (off by default), added the appropriate logic in NewStatusViewModel, and copied the english + four translations that glitch-soc had for the setting

and i think that's pretty much it? is there anything i missed?

<img width="315" alt="cropped screenshot of the bottom of the settings view, showing the new setting, turned on" src="https://user-images.githubusercontent.com/4295016/200709622-ad374ee9-93b7-4cf6-b7ea-9fd1a0edc4ab.png">

<img width="289" alt="cropped screenshot of replying to a post with a content warning. the post being created has the same content warning, but with re: in front!" src="https://user-images.githubusercontent.com/4295016/200709748-743fbd18-4cb8-4e0a-8bca-28bd0bf19c34.png">


### Other Information

- [x] I have signed [Metabolist's Contributor License Agreement](https://metabolist.org/cla)
