### PR TITLE
fixed two bugs when switching accounts from the ComposeView

### DIFF
--- a/ViewModels/Sources/ViewModels/View Models/CompositionViewModel.swift
+++ b/ViewModels/Sources/ViewModels/View Models/CompositionViewModel.swift
@@ -30,7 +30,7 @@ public final class CompositionViewModel: AttachmentsRenderingViewModel, Observab
     public let canRemoveAttachments = true
 
     private let eventsSubject: PassthroughSubject<Event, Never>
-    private let maxCharacters: Int
+    @Published private var maxCharacters: Int
     private var cancellables = Set<AnyCancellable>()
 
     init(eventsSubject: PassthroughSubject<Event, Never>, maxCharacters: Int?) {
@@ -62,8 +62,8 @@ public final class CompositionViewModel: AttachmentsRenderingViewModel, Observab
 
             return tokens.map(\.countShorteningIfURL).reduce(tokens.count - 1, +)
         }
-        .combineLatest($displayContentWarning, $contentWarning)
-        .map { (maxCharacters ?? Self.defaultMaxCharacters) - ($0 + ($1 ? $2.count : 0)) }
+        .combineLatest($displayContentWarning, $contentWarning, $maxCharacters)
+        .map { ($3) - ($0 + ($1 ? $2.count : 0)) }
         .assign(to: &$remainingCharacters)
 
         $displayContentWarning.filter { $0 }.assign(to: &$sensitive)
@@ -85,6 +85,10 @@ public final class CompositionViewModel: AttachmentsRenderingViewModel, Observab
 
     public func removeAttachment(viewModel: AttachmentViewModel) {
         attachmentViewModels.removeAll { $0 === viewModel }
+    }
+
+    public func setMaxCharactersOrDefault(_ newMaxCharacters: Int?) {
+        maxCharacters = newMaxCharacters ?? Self.defaultMaxCharacters
     }
 }
 

--- a/ViewModels/Sources/ViewModels/View Models/NewStatusViewModel.swift
+++ b/ViewModels/Sources/ViewModels/View Models/NewStatusViewModel.swift
@@ -101,6 +101,15 @@ public final class NewStatusViewModel: ObservableObject {
             .sink { [weak self] in self?.handle(event: $0) }
             .store(in: &cancellables)
 
+        $identityContext
+            .map { $0.identity.instance?.maxTootChars }
+            .sink { [weak self] maxTootChars in
+                self?.compositionViewModels.forEach { cvm in
+                    cvm.setMaxCharactersOrDefault(maxTootChars)
+                }
+            }
+            .store(in: &cancellables)
+
         if let identity = identity {
             setIdentity(identity)
         }

--- a/Views/UIKit/CompositionView.swift
+++ b/Views/UIKit/CompositionView.swift
@@ -203,11 +203,14 @@ private extension CompositionView {
                 self.changeIdentityButton.accessibilityLabel = $0.identity.handle
                 self.changeIdentityButton.accessibilityHint =
                     NSLocalizedString("compose.change-identity-button.accessibility-hint", comment: "")
-            }
-            .store(in: &cancellables)
 
-        parentViewModel.identityContext.$authenticatedOtherIdentities
-            .sink { [weak self] in self?.changeIdentityButton.menu = self?.changeIdentityMenu(identities: $0) }
+                $0.$authenticatedOtherIdentities
+                    .sink { [weak self] authenticatedOtherIdentities in
+                        self?.changeIdentityButton.menu =
+                            self?.changeIdentityMenu(identities: authenticatedOtherIdentities)
+                    }
+                    .store(in: &self.cancellables)
+            }
             .store(in: &cancellables)
 
         viewModel.$attachmentViewModels


### PR DESCRIPTION
### Summary

fixes issue #72 

relevant quotes from there that pretty much sum it up:

> Multiple accounts with different maximal chars available. When switching accounts while writing a post: available character count is not updated to the newly selected account.

and

>  if you tap your profile pic a second time to switch back to the original account, it won't show it in the menu

i fixed the first part by:
* making `CompositionViewModel.maxCharacters` into a Publisher
* making the character count recalculate when `$maxCharacters` is updated
* updating `maxCharacters` via a helper method whenever `NewStatusViewModel.$identityContext` is updated

and i fixed the second part, in `CompositionView`, by moving the call to `parentViewModel.identityContext.$authenticatedOtherIdentities.sink()` into the trailing end of the callback given to `parentViewModel.$identityContext.sink()`.

the problem there, originally arose because whenever the user switches accounts, the `identityContext` gets completely replaced by a new object. so when, later on, eventually, the new `identityContext.authenticatedOtherIdentities` got updated, nothing was subscribed to it. and so calling `identityContext.$authenticatedOtherIdentites.sink()` on every change to `identityContext` has fixed it

### Other Information

- [x] I have signed [Metabolist's Contributor License Agreement](https://metabolist.org/cla)
