### PR TITLE
Add HTTPS URL check to accountSettingsURL / editProfileURL

### DIFF
--- a/ViewModels/Sources/ViewModels/View Models/NavigationViewModel.swift
+++ b/ViewModels/Sources/ViewModels/View Models/NavigationViewModel.swift
@@ -224,10 +224,18 @@ public extension NavigationViewModel {
 
 private extension NavigationViewModel {
     func accountSettingsURL(instanceURI: String) -> URL? {
-        URL(string: "https://\(instanceURI)/auth/edit")
+        if instanceURI.hasPrefix("https://") {
+            return URL(string: "\(instanceURI)/auth/edit")
+        } else {
+            return URL(string: "https://\(instanceURI)/auth/edit")
+        }
     }
 
     func editProfileURL(instanceURI: String) -> URL? {
-        URL(string: "https://\(instanceURI)/settings/profile")
+        if instanceURI.hasPrefix("https://") {
+            return URL(string: "\(instanceURI)/settings/profile")
+        } else {
+            return URL(string: "https://\(instanceURI)/settings/profile")
+        }
     }
 }


### PR DESCRIPTION
### Summary

Workaround for instances that registers their URL as "https://instance.url", as this breaks the Account Settings & Edit Profile webviews in Metatext. 

Fixed this by adding check for an existing HTTPS prefix in accountSettingsURL or editProfileURL. 

### Other Information

- [x] I have signed [Metabolist's Contributor License Agreement](https://metabolist.org/cla)
