### PR TITLE
Adapt maxTootChars to new API

### DIFF
--- a/DB/Sources/DB/Extensions/Instance+Extensions.swift
+++ b/DB/Sources/DB/Extensions/Instance+Extensions.swift
@@ -36,6 +36,6 @@ private extension Instance {
                   stats: record.stats,
                   thumbnail: record.thumbnail,
                   contactAccount: contactAccount,
-                  maxTootChars: record.maxTootChars)
+                  configuration: Configuration(statuses: Configuration.Statuses(maxCharacters: record.maxTootChars)))
     }
 }

--- a/Mastodon/Sources/Mastodon/Entities/Instance.swift
+++ b/Mastodon/Sources/Mastodon/Entities/Instance.swift
@@ -13,6 +13,23 @@ public struct Instance: Codable, Hashable {
         public let domainCount: Int
     }
 
+    public struct Configuration: Codable, Hashable {
+        // swiftlint:disable:next nesting
+        public struct Statuses: Codable, Hashable {
+            public let maxCharacters: Int?
+
+            public init(maxCharacters: Int?) {
+                self.maxCharacters = maxCharacters
+            }
+        }
+
+        public let statuses: Statuses?
+
+        public init(statuses: Statuses?) {
+            self.statuses = statuses
+        }
+    }
+
     public let uri: String
     public let title: String
     public let description: String
@@ -27,7 +44,10 @@ public struct Instance: Codable, Hashable {
     public let stats: Stats
     public let thumbnail: UnicodeURL?
     public let contactAccount: Account?
-    public let maxTootChars: Int?
+    public var maxTootChars: Int? {
+        configuration?.statuses?.maxCharacters
+    }
+    public let configuration: Configuration?
 
     public init(uri: String,
                 title: String,
@@ -39,7 +59,7 @@ public struct Instance: Codable, Hashable {
                 stats: Instance.Stats,
                 thumbnail: UnicodeURL?,
                 contactAccount: Account?,
-                maxTootChars: Int?) {
+                configuration: Configuration?) {
         self.uri = uri
         self.title = title
         self.description = description
@@ -50,7 +70,7 @@ public struct Instance: Codable, Hashable {
         self.stats = stats
         self.thumbnail = thumbnail
         self.contactAccount = contactAccount
-        self.maxTootChars = maxTootChars
+        self.configuration = configuration
     }
 }
 


### PR DESCRIPTION
### Summary

In https://github.com/mastodon/mastodon/pull/16485 (July 2021), the API for getting the maximum length of a post/toot changed. I adapted the model accordingly, so that the number gets fetched correctly from the instance.

If, one day, Metatext wants to use more of those `configuration`s, the model needs to be adapted to that accordingly. My implementation here is tailored specifically to the maximum length of a post/toot.

- Fixes #103

### Legal
- [x] I have signed [Metabolist's Contributor License Agreement](https://metabolist.org/cla)
