### PR TITLE
Add preference to override color scheme / appearance

### DIFF
--- a/Localizations/de.lproj/Localizable.strings
+++ b/Localizations/de.lproj/Localizable.strings
@@ -201,6 +201,10 @@
 "preferences" = "Einstellungen";
 "preferences.app" = "App Einstellungen";
 "preferences.app-icon" = "App Icon";
+"preferences.app.color-scheme" = "Erscheinungsbild";
+"preferences.app.color-scheme.dark" = "Dunkel";
+"preferences.app.color-scheme.light" = "Hell";
+"preferences.app.color-scheme.system" = "System";
 "preferences.blocked-domains" = "Gesperrte Domains";
 "preferences.blocked-users" = "Gesperrte Nutzer";
 "preferences.media" = "Medien";

--- a/Localizations/en.lproj/Localizable.strings
+++ b/Localizations/en.lproj/Localizable.strings
@@ -348,7 +348,6 @@
 "status.visibility.unlisted.description" = "Visible for all, but not in public timelines";
 "status.visibility.private.description" = "Visible for followers only";
 "status.visibility.direct.description" = "Visible for mentioned users only";
-"system" = "System";
 "tag.accessibility-recent-uses-%ld" = "%ld recent uses";
 "tag.accessibility-hint.post" = "View posts associated with trend";
 "tag.accessibility-hint.toot" = "View toots associated with trend";

--- a/Localizations/en.lproj/Localizable.strings
+++ b/Localizations/en.lproj/Localizable.strings
@@ -201,6 +201,10 @@
 "preferences" = "Preferences";
 "preferences.app" = "App Preferences";
 "preferences.app-icon" = "App Icon";
+"preferences.app.color-scheme" = "Appearance";
+"preferences.app.color-scheme.dark" = "Dark";
+"preferences.app.color-scheme.light" = "Light";
+"preferences.app.color-scheme.system" = "System";
 "preferences.blocked-domains" = "Blocked Domains";
 "preferences.blocked-users" = "Blocked Users";
 "preferences.media" = "Media";
@@ -344,6 +348,7 @@
 "status.visibility.unlisted.description" = "Visible for all, but not in public timelines";
 "status.visibility.private.description" = "Visible for followers only";
 "status.visibility.direct.description" = "Visible for mentioned users only";
+"system" = "System";
 "tag.accessibility-recent-uses-%ld" = "%ld recent uses";
 "tag.accessibility-hint.post" = "View posts associated with trend";
 "tag.accessibility-hint.toot" = "View toots associated with trend";

--- a/Localizations/es.lproj/Localizable.strings
+++ b/Localizations/es.lproj/Localizable.strings
@@ -201,6 +201,10 @@
 "preferences" = "Ajustes";
 "preferences.app" = "Ajustes de la App";
 "preferences.app-icon" = "Icono de la App";
+"preferences.app.color-scheme" = "Appearance";
+"preferences.app.color-scheme.dark" = "Dark";
+"preferences.app.color-scheme.light" = "Light";
+"preferences.app.color-scheme.system" = "System";
 "preferences.blocked-domains" = "Dominios bloqueados";
 "preferences.blocked-users" = "Usuarios bloqueados";
 "preferences.media" = "Multimedia";

--- a/Localizations/ja.lproj/Localizable.strings
+++ b/Localizations/ja.lproj/Localizable.strings
@@ -201,6 +201,10 @@
 "preferences" = "環境設定";
 "preferences.app" = "アプリ環境設定";
 "preferences.app-icon" = "アプリアイコン";
+"preferences.app.color-scheme" = "Appearance";
+"preferences.app.color-scheme.dark" = "Dark";
+"preferences.app.color-scheme.light" = "Light";
+"preferences.app.color-scheme.system" = "System";
 "preferences.blocked-domains" = "ブロックしたドメイン";
 "preferences.blocked-users" = "ブロックしたユーザー";
 "preferences.media" = "メディア";

--- a/Localizations/ko.lproj/Localizable.strings
+++ b/Localizations/ko.lproj/Localizable.strings
@@ -201,6 +201,10 @@
 "preferences" = "설정";
 "preferences.app" = "앱 설정";
 "preferences.app-icon" = "앱 아이콘";
+"preferences.app.color-scheme" = "Appearance";
+"preferences.app.color-scheme.dark" = "Dark";
+"preferences.app.color-scheme.light" = "Light";
+"preferences.app.color-scheme.system" = "System";
 "preferences.blocked-domains" = "차단된 도메인";
 "preferences.blocked-users" = "차단된 사용자";
 "preferences.media" = "미디어";

--- a/Localizations/pl.lproj/Localizable.strings
+++ b/Localizations/pl.lproj/Localizable.strings
@@ -201,6 +201,10 @@
 "preferences" = "Właściwości";
 "preferences.app" = "Ustawienia aplikacji";
 "preferences.app-icon" = "Ikona aplikacji";
+"preferences.app.color-scheme" = "Appearance";
+"preferences.app.color-scheme.dark" = "Dark";
+"preferences.app.color-scheme.light" = "Light";
+"preferences.app.color-scheme.system" = "System";
 "preferences.blocked-domains" = "Zablokowane domeny";
 "preferences.blocked-users" = "Zablokowane profile";
 "preferences.media" = "Media";

--- a/Localizations/ru.lproj/Localizable.strings
+++ b/Localizations/ru.lproj/Localizable.strings
@@ -201,6 +201,10 @@
 "preferences" = "Настройки";
 "preferences.app" = "Настройки приложения";
 "preferences.app-icon" = "Значок приложения";
+"preferences.app.color-scheme" = "Appearance";
+"preferences.app.color-scheme.dark" = "Dark";
+"preferences.app.color-scheme.light" = "Light";
+"preferences.app.color-scheme.system" = "System";
 "preferences.blocked-domains" = "Заблокированные домены";
 "preferences.blocked-users" = "Заблокированные пользователи";
 "preferences.media" = "Медиафайлы";

--- a/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/Localizations/zh-Hans.lproj/Localizable.strings
@@ -201,6 +201,10 @@
 "preferences" = "偏好设置";
 "preferences.app" = "应用偏好设置";
 "preferences.app-icon" = "应用图标";
+"preferences.app.color-scheme" = "Appearance";
+"preferences.app.color-scheme.dark" = "Dark";
+"preferences.app.color-scheme.light" = "Light";
+"preferences.app.color-scheme.system" = "System";
 "preferences.blocked-domains" = "已屏蔽的域名";
 "preferences.blocked-users" = "已屏蔽的用户";
 "preferences.media" = "媒体";

--- a/ServiceLayer/Sources/ServiceLayer/Utilities/AppPreferences.swift
+++ b/ServiceLayer/Sources/ServiceLayer/Utilities/AppPreferences.swift
@@ -17,6 +17,14 @@ public struct AppPreferences {
 }
 
 public extension AppPreferences {
+    enum ColorScheme: String, CaseIterable, Identifiable {
+        case system
+        case light
+        case dark
+
+        public var id: String { rawValue }
+    }
+
     enum StatusWord: String, CaseIterable, Identifiable {
         case toot
         case post
@@ -45,6 +53,18 @@ public extension AppPreferences {
         case newest
 
         public var id: String { rawValue }
+    }
+
+    var colorScheme: ColorScheme {
+        get {
+            if let rawValue = self[.colorScheme] as String?,
+               let value = ColorScheme(rawValue: rawValue) {
+                return value
+            }
+
+            return .system
+        }
+        set { self[.colorScheme] = newValue.rawValue }
     }
 
     var statusWord: StatusWord {
@@ -185,6 +205,7 @@ public extension AppPreferences {
 
 private extension AppPreferences {
     enum Item: String {
+        case colorScheme
         case statusWord
         case requireDoubleTapToReblog
         case requireDoubleTapToFavorite

--- a/ViewModels/Sources/ViewModels/View Models/NavigationViewModel.swift
+++ b/ViewModels/Sources/ViewModels/View Models/NavigationViewModel.swift
@@ -6,7 +6,7 @@ import Mastodon
 import ServiceLayer
 
 public final class NavigationViewModel: ObservableObject {
-    @Published public private(set) var identityContext: IdentityContext
+    public let identityContext: IdentityContext
     public let navigations: AnyPublisher<Navigation, Never>
 
     @Published public private(set) var recentIdentities = [Identity]()

--- a/ViewModels/Sources/ViewModels/View Models/NavigationViewModel.swift
+++ b/ViewModels/Sources/ViewModels/View Models/NavigationViewModel.swift
@@ -6,7 +6,7 @@ import Mastodon
 import ServiceLayer
 
 public final class NavigationViewModel: ObservableObject {
-    public let identityContext: IdentityContext
+    @Published public private(set) var identityContext: IdentityContext
     public let navigations: AnyPublisher<Navigation, Never>
 
     @Published public private(set) var recentIdentities = [Identity]()

--- a/Views/SwiftUI/PreferencesView.swift
+++ b/Views/SwiftUI/PreferencesView.swift
@@ -88,6 +88,11 @@ struct PreferencesView: View {
                             }
                         }
                     }
+                    Picker("preferences.app.color-scheme", selection: $identityContext.appPreferences.colorScheme) {
+                        ForEach(AppPreferences.ColorScheme.allCases) { option in
+                            Text(option.localizedStringKey).tag(option)
+                        }
+                    }
                     NavigationLink("preferences.notifications",
                                    destination: NotificationPreferencesView(viewModel: viewModel))
                     Picker("preferences.status-word",
@@ -149,6 +154,19 @@ struct PreferencesView: View {
         .onReceive(NotificationCenter.default.publisher(
                     for: UIAccessibility.videoAutoplayStatusDidChangeNotification)) { _ in
             viewModel.objectWillChange.send()
+        }
+    }
+}
+
+extension AppPreferences.ColorScheme {
+    var localizedStringKey: LocalizedStringKey {
+        switch self {
+        case .system:
+            return "preferences.app.color-scheme.system"
+        case .light:
+            return "preferences.app.color-scheme.light"
+        case .dark:
+            return "preferences.app.color-scheme.dark"
         }
     }
 }

--- a/Views/SwiftUI/RootView.swift
+++ b/Views/SwiftUI/RootView.swift
@@ -8,29 +8,26 @@ struct RootView: View {
     @StateObject var viewModel: RootViewModel
 
     var body: some View {
-        Group {
-            if let navigationViewModel = viewModel.navigationViewModel {
-                MainNavigationView { navigationViewModel }
-                    .id(navigationViewModel.identityContext.identity.id)
-                    .environmentObject(viewModel)
-                    .transition(.opacity)
-                    .edgesIgnoringSafeArea(.all)
-                    .onReceive(navigationViewModel.identityContext.$appPreferences.map(\.colorScheme),
-                               perform: setColorScheme)
-            } else {
-                NavigationView {
-                    AddIdentityView(
-                        viewModelClosure: { viewModel.addIdentityViewModel() },
-                        displayWelcome: true)
-                    .navigationBarTitleDisplayMode(.inline)
-                    .navigationBarHidden(true)
-                }
+        if let navigationViewModel = viewModel.navigationViewModel {
+            MainNavigationView { navigationViewModel }
+                .id(navigationViewModel.identityContext.identity.id)
                 .environmentObject(viewModel)
-                .navigationViewStyle(StackNavigationViewStyle())
                 .transition(.opacity)
+                .edgesIgnoringSafeArea(.all)
+                .onReceive(navigationViewModel.identityContext.$appPreferences.map(\.colorScheme),
+                           perform: setColorScheme)
+        } else {
+            NavigationView {
+                AddIdentityView(
+                    viewModelClosure: { viewModel.addIdentityViewModel() },
+                    displayWelcome: true)
+                .navigationBarTitleDisplayMode(.inline)
+                .navigationBarHidden(true)
             }
+            .environmentObject(viewModel)
+            .navigationViewStyle(StackNavigationViewStyle())
+            .transition(.opacity)
         }
-
     }
 }
 

--- a/Views/SwiftUI/RootView.swift
+++ b/Views/SwiftUI/RootView.swift
@@ -1,29 +1,63 @@
 // Copyright © 2020 Metabolist. All rights reserved.
 
 import SwiftUI
+import UIKit
 import ViewModels
 
 struct RootView: View {
     @StateObject var viewModel: RootViewModel
+    @State private var previousColorScheme: AppPreferences.ColorScheme = .system
+    var appPreferencesPublisher: AnyPublisher<AppPreferences, Never> {
+        viewModel.navigationViewModel?.identityContext.$appPreferences.eraseToAnyPublisher()
+            ?? Empty<AppPreferences, Never>().eraseToAnyPublisher()
+    }
 
     var body: some View {
-        if let navigationViewModel = viewModel.navigationViewModel {
-            MainNavigationView { navigationViewModel }
-                .id(navigationViewModel.identityContext.identity.id)
-                .environmentObject(viewModel)
-                .transition(.opacity)
-                .edgesIgnoringSafeArea(.all)
-        } else {
-            NavigationView {
-                AddIdentityView(
-                    viewModelClosure: { viewModel.addIdentityViewModel() },
-                    displayWelcome: true)
+        Group {
+            if let navigationViewModel = viewModel.navigationViewModel {
+                MainNavigationView { navigationViewModel }
+                    .id(navigationViewModel.identityContext.identity.id)
+                    .environmentObject(viewModel)
+                    .transition(.opacity)
+                    .edgesIgnoringSafeArea(.all)
+            } else {
+                NavigationView {
+                    AddIdentityView(
+                        viewModelClosure: { viewModel.addIdentityViewModel() },
+                        displayWelcome: true)
                     .navigationBarTitleDisplayMode(.inline)
                     .navigationBarHidden(true)
+                }
+                .environmentObject(viewModel)
+                .navigationViewStyle(StackNavigationViewStyle())
+                .transition(.opacity)
             }
-            .environmentObject(viewModel)
-            .navigationViewStyle(StackNavigationViewStyle())
-            .transition(.opacity)
+        }
+        .onReceive(appPreferencesPublisher) { preferences in
+            if preferences.colorScheme != previousColorScheme {
+                self.previousColorScheme = preferences.colorScheme
+                setColorScheme(preferences.colorScheme)
+            }
+        }
+    }
+
+    private func setColorScheme(_ colorScheme: AppPreferences.ColorScheme) {
+        let scenes = UIApplication.shared.connectedScenes
+        let windowScenes = scenes.first as? UIWindowScene
+        let window = windowScenes?.windows.first
+        window?.overrideUserInterfaceStyle = colorScheme.uiKit
+    }
+}
+
+extension AppPreferences.ColorScheme {
+    var uiKit: UIUserInterfaceStyle {
+        switch self {
+        case .system:
+            return .unspecified
+        case .light:
+            return .light
+        case .dark:
+            return .dark
         }
     }
 }


### PR DESCRIPTION
### Summary

This PR adds a preference to manually set light/dark mode independently from the system's setting. The color scheme is changed immediately (no need to restart the app) and the setting is saved in UserDefaults together with all the other `AppPreferences`.


### Other Information

- In `NavigationViewModel.swift`, I changed `identityContext` from a `let` constant to a `public private(set) var` and added the `@Published` wrapper, in order to subscribe to changes made in `appPreferences` using Combine. I suppose this doesn't have negative side-effects, but I'm not 100% sure.
- Translations for all languages except EN and DE are still missing, their value is currently in English. I don't really know how the localization workflow for Metatext works in detail, so don't hesitate to correct me here!
- Fixes #73

---

Screenshots (system is currently set to dark mode):

<img width="429" alt="Bildschirm­foto 2022-11-11 um 16 17 19" src="https://user-images.githubusercontent.com/38211057/201370372-f540180b-4b34-4f57-9124-60e06c62cd58.png">
<img width="433" alt="Bildschirm­foto 2022-11-11 um 16 17 26" src="https://user-images.githubusercontent.com/38211057/201370382-745266b7-ed20-4eff-9600-28a1598508a4.png">


### Legal
- [x] I have signed [Metabolist's Contributor License Agreement](https://metabolist.org/cla)
