### PR TITLE
Clean up "require double tap to..." Spanish translations

### DIFF
--- a/Localizations/es.lproj/Localizable.strings
+++ b/Localizations/es.lproj/Localizable.strings
@@ -249,8 +249,8 @@
 "preferences.notifications-position-on-startup" = "Posición de las notificaciones al iniciar";
 "preferences.position.remember-position" = "Recordar posición";
 "preferences.position.newest" = "Cargar más reciente";
-"preferences.require-double-tap-to-reblog" = "Doble toque para rebloguear";
-"preferences.require-double-tap-to-favorite" = "Doble tap para añadir a favoritos";
+"preferences.require-double-tap-to-reblog" = "Requerir doble toque para rebloguear";
+"preferences.require-double-tap-to-favorite" = "Requerir doble toque para añadir a favoritos";
 "preferences.show-reblog-and-favorite-counts" = "Mostrar boost y cuentas favoritas";
 "preferences.status-word" = "Palabra de estado";
 "filters.active" = "Activo";


### PR DESCRIPTION
### Summary
I didn't understand what these settings were supposed to do until I asked someone who uses the app in English what it said on _their_ screen. The word "require" was very necessary. I'd interpreted it as being able to double tap the status to boost/favorite it, and then was confused by how these weren't exclusive settings. (Was the goal to make one gesture that does one, the other, or both, depending on how many toggles are set to true?) With the word "require," it's clearly about preventing accidental boosts/favorites.

So, I'm adding the word "Requerir" to the translation. Also, it seems odd to translate tap to "toque" (touch) in one line and use the Anglicism in the next, so this makes them consistent.

- [x] I have signed [Metabolist's Contributor License Agreement](https://metabolist.org/cla)
