### PR TITLE
Correct the trad. chinese translation of "notifications" of main navigation

### DIFF
--- a/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/Localizations/zh-Hant.lproj/Localizable.strings
@@ -183,7 +183,7 @@
 "main-navigation.announcements" = "公告";
 "main-navigation.timelines" = "時間軸";
 "main-navigation.explore" = "探索";
-"main-navigation.notifications" = "隱藏來自這位使用者的通知？";
+"main-navigation.notifications" = "通知";
 "main-navigation.conversations" = "私訊";
 "metatext" = "Metatext";
 "notification.accessibility.view-profile" = "查看個人資料";


### PR DESCRIPTION
Correct this mistranslation.

![IMG_2377](https://user-images.githubusercontent.com/4880850/202066024-b4ceb60c-ee43-44d3-9224-de8212b79152.jpg)
