### PR TITLE
Add option to hide "show less" cw button, make cw's visually distinct

### DIFF
--- a/Extensions/UIFont+Extensions.swift
+++ b/Extensions/UIFont+Extensions.swift
@@ -1,0 +1,18 @@
+// Copyright © 2022 Metabolist. All rights reserved.
+
+import UIKit
+
+extension UIFont {
+    func withTraits(traits: UIFontDescriptor.SymbolicTraits) -> UIFont {
+        let descriptor = fontDescriptor.withSymbolicTraits(traits)
+        return UIFont(descriptor: descriptor!, size: 0)
+    }
+
+    func bold() -> UIFont {
+        return withTraits(traits: .traitBold)
+    }
+
+    func italic() -> UIFont {
+        return withTraits(traits: .traitItalic)
+    }
+}

--- a/Localizations/en.lproj/Localizable.strings
+++ b/Localizations/en.lproj/Localizable.strings
@@ -253,6 +253,7 @@
 "preferences.require-double-tap-to-favorite" = "Require double tap to favorite";
 "preferences.show-reblog-and-favorite-counts" = "Show boost and favorite counts";
 "preferences.status-word" = "Status word";
+"preferences.hide-content-warning-button" = "Hide \"Show Less\" content warning button";
 "filters.active" = "Active";
 "filters.expired" = "Expired";
 "filter.add-new" = "Add New Filter";

--- a/Metatext.xcodeproj/project.pbxproj
+++ b/Metatext.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		14FC7D32292A556E00567DBC /* UIFont+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14FC7D31292A556E00567DBC /* UIFont+Extensions.swift */; };
 		D0030982250C6C8500EACB32 /* URL+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0030981250C6C8500EACB32 /* URL+Extensions.swift */; };
 		D005A1D825EF189A008B2E63 /* ReportViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D005A1D725EF189A008B2E63 /* ReportViewController.swift */; };
 		D005A1E625EF3D11008B2E63 /* ReportHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D005A1E525EF3D11008B2E63 /* ReportHeaderView.swift */; };
@@ -287,6 +288,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		14FC7D31292A556E00567DBC /* UIFont+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extensions.swift"; sourceTree = "<group>"; };
 		2805F2DF26044E8900670835 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		2805F2E026044E8900670835 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = de; path = de.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		68865A28292346CF001BF177 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -900,6 +902,7 @@
 				D0E7AD3825870B13005F5E2D /* UIVIewController+Extensions.swift */,
 				D0030981250C6C8500EACB32 /* URL+Extensions.swift */,
 				D0C7D46F24F76169001EBDBB /* View+Extensions.swift */,
+				14FC7D31292A556E00567DBC /* UIFont+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1321,6 +1324,7 @@
 				D0DDA76B25C5F20800FA0F91 /* ExploreDataSource.swift in Sources */,
 				D0477F4625C72E50005C5368 /* CapsuleLabel.swift in Sources */,
 				D035F88725B8016000DC75ED /* NavigationViewModel+Extensions.swift in Sources */,
+				14FC7D32292A556E00567DBC /* UIFont+Extensions.swift in Sources */,
 				D0C7D49B24F7616A001EBDBB /* PreferencesView.swift in Sources */,
 				D09D972225C65682007E6394 /* SeparatorConfiguredCollectionViewListCell.swift in Sources */,
 				D088406D25AFBBE200BB749B /* EmojiPickerViewController.swift in Sources */,

--- a/ServiceLayer/Sources/ServiceLayer/Utilities/AppPreferences.swift
+++ b/ServiceLayer/Sources/ServiceLayer/Utilities/AppPreferences.swift
@@ -201,6 +201,11 @@ public extension AppPreferences {
         get { self[.useUniversalLinks] ?? true }
         set { self[.useUniversalLinks] = newValue }
     }
+
+    var hideContentWarningButton: Bool {
+        get { self[.hideContentWarningButton] ?? false }
+        set { self[.hideContentWarningButton] = newValue }
+    }
 }
 
 private extension AppPreferences {
@@ -223,6 +228,7 @@ private extension AppPreferences {
         case notificationSounds
         case openLinksInDefaultBrowser
         case useUniversalLinks
+        case hideContentWarningButton
     }
 
     subscript<T>(index: Item) -> T? {

--- a/ViewModels/Sources/ViewModels/View Models/StatusViewModel.swift
+++ b/ViewModels/Sources/ViewModels/View Models/StatusViewModel.swift
@@ -62,6 +62,14 @@ public extension StatusViewModel {
         }
     }
 
+    var shouldShowContentWarningButton: Bool {
+        if self.shouldShowContent {
+            return !identityContext.appPreferences.hideContentWarningButton
+        } else {
+            return true
+        }
+    }
+
     var shouldShowAttachments: Bool {
         switch identityContext.identity.preferences.readingExpandMedia {
         case .default, .unknown:

--- a/Views/SwiftUI/PreferencesView.swift
+++ b/Views/SwiftUI/PreferencesView.swift
@@ -137,6 +137,8 @@ struct PreferencesView: View {
                            isOn: $identityContext.appPreferences.animateCustomEmojis)
                     Toggle("preferences.media.headers.animate",
                            isOn: $identityContext.appPreferences.animateHeaders)
+                    Toggle("preferences.hide-content-warning-button",
+                           isOn: $identityContext.appPreferences.hideContentWarningButton)
                 }
                 if viewModel.identityContext.identity.authenticated
                     && !viewModel.identityContext.identity.pending {

--- a/Views/UIKit/StatusBodyView.swift
+++ b/Views/UIKit/StatusBodyView.swift
@@ -19,6 +19,7 @@ final class StatusBodyView: UIView {
             let isContextParent = viewModel.configuration.isContextParent
             let mutableContent = NSMutableAttributedString(attributedString: viewModel.content)
             let mutableSpoilerText = NSMutableAttributedString(string: viewModel.spoilerText)
+            let mutableSpoilerFont = UIFont.preferredFont(forTextStyle: isContextParent ? .title3 : .callout).bold()
             let contentFont = UIFont.preferredFont(forTextStyle: isContextParent ? .title3 : .callout)
             let contentRange = NSRange(location: 0, length: mutableContent.length)
 
@@ -39,7 +40,7 @@ final class StatusBodyView: UIView {
                                       view: spoilerTextLabel,
                                       identityContext: viewModel.identityContext)
             mutableSpoilerText.resizeAttachments(toLineHeight: spoilerTextLabel.font.lineHeight)
-            spoilerTextLabel.font = contentFont
+            spoilerTextLabel.font = mutableSpoilerFont
             spoilerTextLabel.attributedText = mutableSpoilerText
             spoilerTextLabel.isHidden = spoilerTextLabel.text == ""
             toggleShowContentButton.setTitle(
@@ -48,6 +49,7 @@ final class StatusBodyView: UIView {
                     : NSLocalizedString("status.show-more", comment: ""),
                 for: .normal)
             toggleShowContentButton.isHidden = viewModel.spoilerText.isEmpty
+                    || !viewModel.shouldShowContentWarningButton
 
             contentTextView.isHidden = !viewModel.shouldShowContent
 


### PR DESCRIPTION
### Summary

This PR implements #182, making threads more readable for folk who might have content warnings always expanded.

Content warning's have been made bold to distinguish from post content.

Before:
<img width="412" alt="image" src="https://user-images.githubusercontent.com/4761786/202926052-9a5b9248-6f31-4823-b6a2-7f1c023e33d3.jpeg">

After:
<img width="412" alt="image" src="https://user-images.githubusercontent.com/4761786/202926037-ef6e1fea-38ab-4cad-8712-5a207f0579b0.png">


### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.

Thanks for contributing to Metatext! -->

- [x] I have signed [Metabolist's Contributor License Agreement](https://metabolist.org/cla)
