### PR TITLE
Fix crash when muting account

### DIFF
--- a/ViewModels/Sources/ViewModels/View Models/CollectionItemsViewModel.swift
+++ b/ViewModels/Sources/ViewModels/View Models/CollectionItemsViewModel.swift
@@ -98,6 +98,10 @@ public class CollectionItemsViewModel: ObservableObject {
 
     // swiftlint:disable:next function_body_length cyclomatic_complexity
     public func viewModel(indexPath: IndexPath) -> Any {
+        guard indexPath.section < lastUpdate.sections.count,
+              indexPath.item < lastUpdate.sections[indexPath.section].items.count else {
+            return false
+        }
         let item = lastUpdate.sections[indexPath.section].items[indexPath.item]
         let cachedViewModel = viewModelCache[item]
 

--- a/ViewModels/Sources/ViewModels/View Models/CollectionItemsViewModel.swift
+++ b/ViewModels/Sources/ViewModels/View Models/CollectionItemsViewModel.swift
@@ -97,11 +97,11 @@ public class CollectionItemsViewModel: ObservableObject {
     }
 
     // swiftlint:disable:next function_body_length cyclomatic_complexity
-    public func viewModel(indexPath: IndexPath) -> Any {
+    public func viewModel(indexPath: IndexPath) -> Any? {
         guard indexPath.section < lastUpdate.sections.count,
-              indexPath.item < lastUpdate.sections[indexPath.section].items.count else {
-            return false
-        }
+              indexPath.item < lastUpdate.sections[indexPath.section].items.count
+        else { return nil }
+
         let item = lastUpdate.sections[indexPath.section].items[indexPath.item]
         let cachedViewModel = viewModelCache[item]
 

--- a/ViewModels/Sources/ViewModels/View Models/CollectionViewModel.swift
+++ b/ViewModels/Sources/ViewModels/View Models/CollectionViewModel.swift
@@ -22,7 +22,7 @@ public protocol CollectionViewModel {
     func viewedAtTop(indexPath: IndexPath)
     func select(indexPath: IndexPath)
     func canSelect(indexPath: IndexPath) -> Bool
-    func viewModel(indexPath: IndexPath) -> Any
+    func viewModel(indexPath: IndexPath) -> Any?
     func toggleExpandAll()
     func applyAccountListEdit(viewModel: AccountViewModel, edit: CollectionItemEvent.AccountListEdit)
 }

--- a/ViewModels/Sources/ViewModels/View Models/ProfileViewModel.swift
+++ b/ViewModels/Sources/ViewModels/View Models/ProfileViewModel.swift
@@ -178,7 +178,7 @@ extension ProfileViewModel: CollectionViewModel {
         collectionViewModel.value.canSelect(indexPath: indexPath)
     }
 
-    public func viewModel(indexPath: IndexPath) -> Any {
+    public func viewModel(indexPath: IndexPath) -> Any? {
         collectionViewModel.value.viewModel(indexPath: indexPath)
     }
 


### PR DESCRIPTION
### Summary

This is a fix/workaround for the crash that happened sometimes after muting a profile.

The root cause seems to be the fact that cached posts are deleted from the database upon muting, which results in `lastUpdate` containing no `item`s anymore, which leads to an index-out-of-bounds error when trying to access it.

### Other Information

Fixes #48.

- [x] I have signed [Metabolist's Contributor License Agreement](https://metabolist.org/cla)
- [x] The proposed changes are limited in scope to fixing bugs, or I have discussed larger scope changes via email
