### PR TITLE
Add support for default keyboard in composition view

### DIFF
--- a/Localizations/ca.lproj/Localizable.strings
+++ b/Localizations/ca.lproj/Localizable.strings
@@ -254,8 +254,8 @@
 "preferences.show-reblog-and-favorite-counts" = "Mostra el recompte d’impulsos i favorits";
 "preferences.status-word" = "Paraula d’estat";
 "preferences.keyboard-type" = "Teclat";
-"preferences.keyboard-type.twitter" = "Twitter";
-"preferences.keyboard-type.default-text" = "Per defecte";
+"preferences.keyboard-type.twitter" = "Amb clau hash";
+"preferences.keyboard-type.default-text" = "Amb la tecla enter";
 "filters.active" = "Actiu";
 "filters.expired" = "Caducat";
 "filter.add-new" = "Afegeix un filtre nou";

--- a/Localizations/ca.lproj/Localizable.strings
+++ b/Localizations/ca.lproj/Localizable.strings
@@ -253,6 +253,9 @@
 "preferences.require-double-tap-to-favorite" = "Cal que toquis dues vegades per fer-ho favorit";
 "preferences.show-reblog-and-favorite-counts" = "Mostra el recompte d’impulsos i favorits";
 "preferences.status-word" = "Paraula d’estat";
+"preferences.keyboard-type" = "Teclat";
+"preferences.keyboard-type.twitter" = "Twitter";
+"preferences.keyboard-type.default-text" = "Per defecte";
 "filters.active" = "Actiu";
 "filters.expired" = "Caducat";
 "filter.add-new" = "Afegeix un filtre nou";

--- a/Localizations/cs.lproj/Localizable.strings
+++ b/Localizations/cs.lproj/Localizable.strings
@@ -254,8 +254,8 @@
 "preferences.show-reblog-and-favorite-counts" = "Zobrazit boostů a počet oblíbených";
 "preferences.status-word" = "Toot/Příspěvek";
 "preferences.keyboard-type" = "Klávesnice";
-"preferences.keyboard-type.twitter" = "Twitter";
-"preferences.keyboard-type.default-text" = "Výchozí";
+"preferences.keyboard-type.twitter" = "S hash klíčem";
+"preferences.keyboard-type.default-text" = "S klávesou enter";
 "filters.active" = "Aktivní";
 "filters.expired" = "Platnost vypršela";
 "filter.add-new" = "Přidat nový filtr";

--- a/Localizations/cs.lproj/Localizable.strings
+++ b/Localizations/cs.lproj/Localizable.strings
@@ -253,6 +253,9 @@
 "preferences.require-double-tap-to-favorite" = "Vyžadovat dvojité klepnutí pro oblíbené";
 "preferences.show-reblog-and-favorite-counts" = "Zobrazit boostů a počet oblíbených";
 "preferences.status-word" = "Toot/Příspěvek";
+"preferences.keyboard-type" = "Klávesnice";
+"preferences.keyboard-type.twitter" = "Twitter";
+"preferences.keyboard-type.default-text" = "Výchozí";
 "filters.active" = "Aktivní";
 "filters.expired" = "Platnost vypršela";
 "filter.add-new" = "Přidat nový filtr";

--- a/Localizations/de.lproj/Localizable.strings
+++ b/Localizations/de.lproj/Localizable.strings
@@ -254,8 +254,8 @@
 "preferences.show-reblog-and-favorite-counts" = "Boosts und Favoriten anzeigen";
 "preferences.status-word" = "Statuswort";
 "preferences.keyboard-type" = "Tastatur";
-"preferences.keyboard-type.twitter" = "Twitter";
-"preferences.keyboard-type.default-text" = "Standard";
+"preferences.keyboard-type.twitter" = "Mit Rautetaste";
+"preferences.keyboard-type.default-text" = "Mit Eingabetaste";
 "filters.active" = "Aktiv";
 "filters.expired" = "Abgelaufen";
 "filter.add-new" = "Neuer Filter";

--- a/Localizations/de.lproj/Localizable.strings
+++ b/Localizations/de.lproj/Localizable.strings
@@ -253,6 +253,9 @@
 "preferences.require-double-tap-to-favorite" = "Doppelklick zum Favorisieren";
 "preferences.show-reblog-and-favorite-counts" = "Boosts und Favoriten anzeigen";
 "preferences.status-word" = "Statuswort";
+"preferences.keyboard-type" = "Tastatur";
+"preferences.keyboard-type.twitter" = "Twitter";
+"preferences.keyboard-type.default-text" = "Standard";
 "filters.active" = "Aktiv";
 "filters.expired" = "Abgelaufen";
 "filter.add-new" = "Neuer Filter";

--- a/Localizations/el.lproj/Localizable.strings
+++ b/Localizations/el.lproj/Localizable.strings
@@ -254,8 +254,8 @@
 "preferences.show-reblog-and-favorite-counts" = "Εμφάνιση μετρήσεων των boosts και αγαπημένων";
 "preferences.status-word" = "Λέξη κατάστασης";
 "preferences.keyboard-type" = "Πληκτρολόγιο";
-"preferences.keyboard-type.twitter" = "Twitter";
-"preferences.keyboard-type.default-text" = "Προκαθορισμένο";
+"preferences.keyboard-type.twitter" = "Με κλειδί κατακερματισμού";
+"preferences.keyboard-type.default-text" = "Με το πλήκτρο enter";
 "filters.active" = "Ενεργό";
 "filters.expired" = "Έληξε";
 "filter.add-new" = "Προσθήκη Νέου Φίλτρου";

--- a/Localizations/el.lproj/Localizable.strings
+++ b/Localizations/el.lproj/Localizable.strings
@@ -253,6 +253,9 @@
 "preferences.require-double-tap-to-favorite" = "Να απαιτείται διπλό πάτημα για προσθήκη στα αγαπημένα";
 "preferences.show-reblog-and-favorite-counts" = "Εμφάνιση μετρήσεων των boosts και αγαπημένων";
 "preferences.status-word" = "Λέξη κατάστασης";
+"preferences.keyboard-type" = "Πληκτρολόγιο";
+"preferences.keyboard-type.twitter" = "Twitter";
+"preferences.keyboard-type.default-text" = "Προκαθορισμένο";
 "filters.active" = "Ενεργό";
 "filters.expired" = "Έληξε";
 "filter.add-new" = "Προσθήκη Νέου Φίλτρου";

--- a/Localizations/en.lproj/Localizable.strings
+++ b/Localizations/en.lproj/Localizable.strings
@@ -254,8 +254,8 @@
 "preferences.show-reblog-and-favorite-counts" = "Show boost and favorite counts";
 "preferences.status-word" = "Status word";
 "preferences.keyboard-type" = "Keyboard";
-"preferences.keyboard-type.twitter" = "Twitter";
-"preferences.keyboard-type.default-text" = "Default";
+"preferences.keyboard-type.twitter" = "With hash key";
+"preferences.keyboard-type.default-text" = "With enter key";
 "filters.active" = "Active";
 "filters.expired" = "Expired";
 "filter.add-new" = "Add New Filter";

--- a/Localizations/en.lproj/Localizable.strings
+++ b/Localizations/en.lproj/Localizable.strings
@@ -253,6 +253,9 @@
 "preferences.require-double-tap-to-favorite" = "Require double tap to favorite";
 "preferences.show-reblog-and-favorite-counts" = "Show boost and favorite counts";
 "preferences.status-word" = "Status word";
+"preferences.keyboard-type" = "Keyboard";
+"preferences.keyboard-type.twitter" = "Twitter";
+"preferences.keyboard-type.default-text" = "Default";
 "filters.active" = "Active";
 "filters.expired" = "Expired";
 "filter.add-new" = "Add New Filter";

--- a/Localizations/es.lproj/Localizable.strings
+++ b/Localizations/es.lproj/Localizable.strings
@@ -253,6 +253,9 @@
 "preferences.require-double-tap-to-favorite" = "Requerir doble toque para añadir a favoritos";
 "preferences.show-reblog-and-favorite-counts" = "Mostrar boost y cuentas favoritas";
 "preferences.status-word" = "Palabra de estado";
+"preferences.keyboard-type" = "Teclado";
+"preferences.keyboard-type.twitter" = "Twitter";
+"preferences.keyboard-type.default-text" = "Defecto";
 "filters.active" = "Activo";
 "filters.expired" = "Ha caducado";
 "filter.add-new" = "Añadir un filtro nuevo";

--- a/Localizations/es.lproj/Localizable.strings
+++ b/Localizations/es.lproj/Localizable.strings
@@ -254,8 +254,8 @@
 "preferences.show-reblog-and-favorite-counts" = "Mostrar boost y cuentas favoritas";
 "preferences.status-word" = "Palabra de estado";
 "preferences.keyboard-type" = "Teclado";
-"preferences.keyboard-type.twitter" = "Twitter";
-"preferences.keyboard-type.default-text" = "Defecto";
+"preferences.keyboard-type.twitter" = "Con clave hash";
+"preferences.keyboard-type.default-text" = "Con tecla enter";
 "filters.active" = "Activo";
 "filters.expired" = "Ha caducado";
 "filter.add-new" = "Añadir un filtro nuevo";

--- a/Localizations/eu.lproj/Localizable.strings
+++ b/Localizations/eu.lproj/Localizable.strings
@@ -254,8 +254,8 @@
 "preferences.show-reblog-and-favorite-counts" = "Erakutsi bultzada eta gogoko kopurua";
 "preferences.status-word" = "Nahiago duzun hitza";
 "preferences.keyboard-type" = "Teklatua";
-"preferences.keyboard-type.twitter" = "Twitter";
-"preferences.keyboard-type.default-text" = "Lehenetsia";
+"preferences.keyboard-type.twitter" = "Hash giltzarekin";
+"preferences.keyboard-type.default-text" = "Sartu teklarekin";
 "filters.active" = "Aktibo";
 "filters.expired" = "Iraungita";
 "filter.add-new" = "Gehitu iragazki berria";

--- a/Localizations/eu.lproj/Localizable.strings
+++ b/Localizations/eu.lproj/Localizable.strings
@@ -253,6 +253,9 @@
 "preferences.require-double-tap-to-favorite" = "Gogoko egiteko birritan sakatu behar da";
 "preferences.show-reblog-and-favorite-counts" = "Erakutsi bultzada eta gogoko kopurua";
 "preferences.status-word" = "Nahiago duzun hitza";
+"preferences.keyboard-type" = "Teklatua";
+"preferences.keyboard-type.twitter" = "Twitter";
+"preferences.keyboard-type.default-text" = "Lehenetsia";
 "filters.active" = "Aktibo";
 "filters.expired" = "Iraungita";
 "filter.add-new" = "Gehitu iragazki berria";

--- a/Localizations/fr.lproj/Localizable.strings
+++ b/Localizations/fr.lproj/Localizable.strings
@@ -253,6 +253,9 @@
 "preferences.require-double-tap-to-favorite" = "Nécessite un double appui pour ajouter aux favoris";
 "preferences.show-reblog-and-favorite-counts" = "Afficher le nombre de partages/favoris";
 "preferences.status-word" = "Mot de statut";
+"preferences.keyboard-type" = "Clavier";
+"preferences.keyboard-type.twitter" = "Twitter";
+"preferences.keyboard-type.default-text" = "Défaut";
 "filters.active" = "Actifs";
 "filters.expired" = "Expirés";
 "filter.add-new" = "Ajouter un nouveau filtre";

--- a/Localizations/fr.lproj/Localizable.strings
+++ b/Localizations/fr.lproj/Localizable.strings
@@ -254,8 +254,8 @@
 "preferences.show-reblog-and-favorite-counts" = "Afficher le nombre de partages/favoris";
 "preferences.status-word" = "Mot de statut";
 "preferences.keyboard-type" = "Clavier";
-"preferences.keyboard-type.twitter" = "Twitter";
-"preferences.keyboard-type.default-text" = "Défaut";
+"preferences.keyboard-type.twitter" = "Avec clé de hachage";
+"preferences.keyboard-type.default-text" = "Avec la touche entrée";
 "filters.active" = "Actifs";
 "filters.expired" = "Expirés";
 "filter.add-new" = "Ajouter un nouveau filtre";

--- a/Localizations/gd.lproj/Localizable.strings
+++ b/Localizations/gd.lproj/Localizable.strings
@@ -254,8 +254,8 @@
 "preferences.show-reblog-and-favorite-counts" = "Seall cunntas nam brosnachaidhean ’s nan annsachdan";
 "preferences.status-word" = "Facal puist";
 "preferences.keyboard-type" = "Meur-chlàr";
-"preferences.keyboard-type.twitter" = "Twitter";
-"preferences.keyboard-type.default-text" = "Bunaiteach";
+"preferences.keyboard-type.twitter" = "Le iuchair hash";
+"preferences.keyboard-type.default-text" = "Leis an iuchair cuir a-steach";
 "filters.active" = "Gnìomhach";
 "filters.expired" = "Thàinig e gu crìoch";
 "filter.add-new" = "Cuir criathrag ùr ris";

--- a/Localizations/gd.lproj/Localizable.strings
+++ b/Localizations/gd.lproj/Localizable.strings
@@ -253,6 +253,9 @@
 "preferences.require-double-tap-to-favorite" = "Thoir gnogag dhùbailte airson annsachd a chruthachadh";
 "preferences.show-reblog-and-favorite-counts" = "Seall cunntas nam brosnachaidhean ’s nan annsachdan";
 "preferences.status-word" = "Facal puist";
+"preferences.keyboard-type" = "Meur-chlàr";
+"preferences.keyboard-type.twitter" = "Twitter";
+"preferences.keyboard-type.default-text" = "Bunaiteach";
 "filters.active" = "Gnìomhach";
 "filters.expired" = "Thàinig e gu crìoch";
 "filter.add-new" = "Cuir criathrag ùr ris";

--- a/Localizations/he.lproj/Localizable.strings
+++ b/Localizations/he.lproj/Localizable.strings
@@ -254,8 +254,8 @@
 "preferences.show-reblog-and-favorite-counts" = "הצג מספר הדהודים וחיבובים";
 "preferences.status-word" = "מילת סטטוס";
 "preferences.keyboard-type" = "מקלדת";
-"preferences.keyboard-type.twitter" = "Twitter";
-"preferences.keyboard-type.default-text" = "בְּרִירַת מֶחדָל";
+"preferences.keyboard-type.twitter" = "עם מפתח hash";
+"preferences.keyboard-type.default-text" = "עם מקש אנטר";
 "filters.active" = "פעיל";
 "filters.expired" = "פג תוקף";
 "filter.add-new" = "הוספת מסנן חדש";

--- a/Localizations/he.lproj/Localizable.strings
+++ b/Localizations/he.lproj/Localizable.strings
@@ -253,6 +253,9 @@
 "preferences.require-double-tap-to-favorite" = "דרוש לחיצה כפולה כדי להדהד";
 "preferences.show-reblog-and-favorite-counts" = "הצג מספר הדהודים וחיבובים";
 "preferences.status-word" = "מילת סטטוס";
+"preferences.keyboard-type" = "מקלדת";
+"preferences.keyboard-type.twitter" = "Twitter";
+"preferences.keyboard-type.default-text" = "בְּרִירַת מֶחדָל";
 "filters.active" = "פעיל";
 "filters.expired" = "פג תוקף";
 "filter.add-new" = "הוספת מסנן חדש";

--- a/Localizations/ja.lproj/Localizable.strings
+++ b/Localizations/ja.lproj/Localizable.strings
@@ -253,6 +253,9 @@
 "preferences.require-double-tap-to-favorite" = "ダブルタップでお気に入り";
 "preferences.show-reblog-and-favorite-counts" = "ブースト・お気に入り数を表示";
 "preferences.status-word" = "ステータスを表す言葉";
+"preferences.keyboard-type" = "キーボード";
+"preferences.keyboard-type.twitter" = "Twitter";
+"preferences.keyboard-type.default-text" = "デフォルト";
 "filters.active" = "有効";
 "filters.expired" = "期限切れ";
 "filter.add-new" = "新しいフィルターを追加";

--- a/Localizations/ja.lproj/Localizable.strings
+++ b/Localizations/ja.lproj/Localizable.strings
@@ -254,8 +254,8 @@
 "preferences.show-reblog-and-favorite-counts" = "ブースト・お気に入り数を表示";
 "preferences.status-word" = "ステータスを表す言葉";
 "preferences.keyboard-type" = "キーボード";
-"preferences.keyboard-type.twitter" = "Twitter";
-"preferences.keyboard-type.default-text" = "デフォルト";
+"preferences.keyboard-type.twitter" = "ハッシュキーあり";
+"preferences.keyboard-type.default-text" = "エンターキーあり";
 "filters.active" = "有効";
 "filters.expired" = "期限切れ";
 "filter.add-new" = "新しいフィルターを追加";

--- a/Localizations/ko.lproj/Localizable.strings
+++ b/Localizations/ko.lproj/Localizable.strings
@@ -253,6 +253,9 @@
 "preferences.require-double-tap-to-favorite" = "두 번 탭 해서 즐겨찾기";
 "preferences.show-reblog-and-favorite-counts" = "부스트 및 즐겨찾기 수 표시";
 "preferences.status-word" = "상태를 나타내는 말";
+"preferences.keyboard-type" = "건반";
+"preferences.keyboard-type.twitter" = "Twitter";
+"preferences.keyboard-type.default-text" = "기본";
 "filters.active" = "활성화";
 "filters.expired" = "만료됨";
 "filter.add-new" = "새 필터 추가";

--- a/Localizations/ko.lproj/Localizable.strings
+++ b/Localizations/ko.lproj/Localizable.strings
@@ -254,8 +254,8 @@
 "preferences.show-reblog-and-favorite-counts" = "부스트 및 즐겨찾기 수 표시";
 "preferences.status-word" = "상태를 나타내는 말";
 "preferences.keyboard-type" = "건반";
-"preferences.keyboard-type.twitter" = "Twitter";
-"preferences.keyboard-type.default-text" = "기본";
+"preferences.keyboard-type.twitter" = "해시 키 사용";
+"preferences.keyboard-type.default-text" = "엔터키로";
 "filters.active" = "활성화";
 "filters.expired" = "만료됨";
 "filter.add-new" = "새 필터 추가";

--- a/Localizations/pl.lproj/Localizable.strings
+++ b/Localizations/pl.lproj/Localizable.strings
@@ -253,6 +253,9 @@
 "preferences.require-double-tap-to-favorite" = "Wymagaj podwójnego stuknięcia do polubienia";
 "preferences.show-reblog-and-favorite-counts" = "Pokazuj licznik podbić i polubień";
 "preferences.status-word" = "Używaj jako nazwy statusu";
+"preferences.keyboard-type" = "Klawiatura";
+"preferences.keyboard-type.twitter" = "Twitter";
+"preferences.keyboard-type.default-text" = "Domyślna";
 "filters.active" = "Aktywny";
 "filters.expired" = "Wygasły";
 "filter.add-new" = "Dodaj nowy filtr";

--- a/Localizations/pl.lproj/Localizable.strings
+++ b/Localizations/pl.lproj/Localizable.strings
@@ -254,8 +254,8 @@
 "preferences.show-reblog-and-favorite-counts" = "Pokazuj licznik podbić i polubień";
 "preferences.status-word" = "Używaj jako nazwy statusu";
 "preferences.keyboard-type" = "Klawiatura";
-"preferences.keyboard-type.twitter" = "Twitter";
-"preferences.keyboard-type.default-text" = "Domyślna";
+"preferences.keyboard-type.twitter" = "Z kluczem krzyżykowym";
+"preferences.keyboard-type.default-text" = "Z klawiszem Enter";
 "filters.active" = "Aktywny";
 "filters.expired" = "Wygasły";
 "filter.add-new" = "Dodaj nowy filtr";

--- a/Localizations/pt-BR.lproj/Localizable.strings
+++ b/Localizations/pt-BR.lproj/Localizable.strings
@@ -254,7 +254,7 @@
 "preferences.show-reblog-and-favorite-counts" = "Mostrar contagem de boosts e favoritos";
 "preferences.status-word" = "Estado da palavra";
 "preferences.keyboard-type" = "Teclado";
-"preferences.keyboard-type.twitter" = "Twitter";
+"preferences.keyboard-type.twitter" = "Com chave hash";
 "preferences.keyboard-type.default-text" = "Predefinição";
 "filters.active" = "Ativo";
 "filters.expired" = "Expirados";

--- a/Localizations/pt-BR.lproj/Localizable.strings
+++ b/Localizations/pt-BR.lproj/Localizable.strings
@@ -253,6 +253,9 @@
 "preferences.require-double-tap-to-favorite" = "Solicitar toque duplo para favoritar";
 "preferences.show-reblog-and-favorite-counts" = "Mostrar contagem de boosts e favoritos";
 "preferences.status-word" = "Estado da palavra";
+"preferences.keyboard-type" = "Teclado";
+"preferences.keyboard-type.twitter" = "Twitter";
+"preferences.keyboard-type.default-text" = "Predefinição";
 "filters.active" = "Ativo";
 "filters.expired" = "Expirados";
 "filter.add-new" = "Adicionar Novo Filtro";

--- a/Localizations/ru.lproj/Localizable.strings
+++ b/Localizations/ru.lproj/Localizable.strings
@@ -253,6 +253,9 @@
 "preferences.require-double-tap-to-favorite" = "Требуется двойное нажатие для добавления в избранное";
 "preferences.show-reblog-and-favorite-counts" = "Показать счётчик продвижений и добавлений в избранное";
 "preferences.status-word" = "Название статусов";
+"preferences.keyboard-type" = "Клавиатура";
+"preferences.keyboard-type.twitter" = "Twitter";
+"preferences.keyboard-type.default-text" = "дефолт";
 "filters.active" = "Активный";
 "filters.expired" = "Истёк";
 "filter.add-new" = "Добавить новый фильтр";

--- a/Localizations/ru.lproj/Localizable.strings
+++ b/Localizations/ru.lproj/Localizable.strings
@@ -254,8 +254,8 @@
 "preferences.show-reblog-and-favorite-counts" = "Показать счётчик продвижений и добавлений в избранное";
 "preferences.status-word" = "Название статусов";
 "preferences.keyboard-type" = "Клавиатура";
-"preferences.keyboard-type.twitter" = "Twitter";
-"preferences.keyboard-type.default-text" = "дефолт";
+"preferences.keyboard-type.twitter" = "С хэш-ключом";
+"preferences.keyboard-type.default-text" = "С клавишей ввода";
 "filters.active" = "Активный";
 "filters.expired" = "Истёк";
 "filter.add-new" = "Добавить новый фильтр";

--- a/Localizations/sv.lproj/Localizable.strings
+++ b/Localizations/sv.lproj/Localizable.strings
@@ -253,6 +253,9 @@
 "preferences.require-double-tap-to-favorite" = "Kräv dubbeltryck för att favoritmarkera";
 "preferences.show-reblog-and-favorite-counts" = "Visa antal boosts och favoritmarkeringar";
 "preferences.status-word" = "Statusord";
+"preferences.keyboard-type" = "Tangentbord";
+"preferences.keyboard-type.twitter" = "Twitter";
+"preferences.keyboard-type.default-text" = "Standard";
 "filters.active" = "Aktiv";
 "filters.expired" = "Upphört";
 "filter.add-new" = "Lägg till nytt filter";

--- a/Localizations/sv.lproj/Localizable.strings
+++ b/Localizations/sv.lproj/Localizable.strings
@@ -254,7 +254,7 @@
 "preferences.show-reblog-and-favorite-counts" = "Visa antal boosts och favoritmarkeringar";
 "preferences.status-word" = "Statusord";
 "preferences.keyboard-type" = "Tangentbord";
-"preferences.keyboard-type.twitter" = "Twitter";
+"preferences.keyboard-type.twitter" = "Med hash-nyckel";
 "preferences.keyboard-type.default-text" = "Standard";
 "filters.active" = "Aktiv";
 "filters.expired" = "Upphört";

--- a/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/Localizations/zh-Hans.lproj/Localizable.strings
@@ -253,6 +253,9 @@
 "preferences.require-double-tap-to-favorite" = "需要双击才能点赞";
 "preferences.show-reblog-and-favorite-counts" = "显示转发与点赞的计数";
 "preferences.status-word" = "表述状态用的词";
+"preferences.keyboard-type" = "键盘";
+"preferences.keyboard-type.twitter" = "Twitter";
+"preferences.keyboard-type.default-text" = "默认";
 "filters.active" = "已启用";
 "filters.expired" = "已过期";
 "filter.add-new" = "添加新筛选器";

--- a/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/Localizations/zh-Hans.lproj/Localizable.strings
@@ -254,8 +254,8 @@
 "preferences.show-reblog-and-favorite-counts" = "显示转发与点赞的计数";
 "preferences.status-word" = "表述状态用的词";
 "preferences.keyboard-type" = "键盘";
-"preferences.keyboard-type.twitter" = "Twitter";
-"preferences.keyboard-type.default-text" = "默认";
+"preferences.keyboard-type.twitter" = "带散列键";
+"preferences.keyboard-type.default-text" = "用回车键";
 "filters.active" = "已启用";
 "filters.expired" = "已过期";
 "filter.add-new" = "添加新筛选器";

--- a/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/Localizations/zh-Hant.lproj/Localizable.strings
@@ -253,6 +253,9 @@
 "preferences.require-double-tap-to-favorite" = "需要點按兩次才能收藏";
 "preferences.show-reblog-and-favorite-counts" = "顯示轉嘟與收藏的次數";
 "preferences.status-word" = "狀態字";
+"preferences.keyboard-type" = "鍵盤";
+"preferences.keyboard-type.twitter" = "Twitter";
+"preferences.keyboard-type.default-text" = "默認";
 "filters.active" = "已啟用";
 "filters.expired" = "已過期";
 "filter.add-new" = "新增篩選器";

--- a/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/Localizations/zh-Hant.lproj/Localizable.strings
@@ -254,8 +254,8 @@
 "preferences.show-reblog-and-favorite-counts" = "顯示轉嘟與收藏的次數";
 "preferences.status-word" = "狀態字";
 "preferences.keyboard-type" = "鍵盤";
-"preferences.keyboard-type.twitter" = "Twitter";
-"preferences.keyboard-type.default-text" = "默認";
+"preferences.keyboard-type.twitter" = "使用哈希鍵";
+"preferences.keyboard-type.default-text" = "用回車鍵";
 "filters.active" = "已啟用";
 "filters.expired" = "已過期";
 "filter.add-new" = "新增篩選器";

--- a/ServiceLayer/Sources/ServiceLayer/Utilities/AppPreferences.swift
+++ b/ServiceLayer/Sources/ServiceLayer/Utilities/AppPreferences.swift
@@ -40,6 +40,13 @@ public extension AppPreferences {
         public var id: String { rawValue }
     }
 
+    enum KeyboardType: String, CaseIterable, Identifiable {
+        case twitter
+        case defaultText
+
+        public var id: String { rawValue }
+    }
+
     enum Autoplay: String, CaseIterable, Identifiable {
         case always
         case wifi
@@ -89,6 +96,18 @@ public extension AppPreferences {
             return systemReduceMotion() ? .never : .everywhere
         }
         set { self[.animateAvatars] = newValue.rawValue }
+    }
+
+    var keyboardType: KeyboardType {
+        get {
+            if let rawValue = self[.keyboardType] as String?,
+               let value = KeyboardType(rawValue: rawValue) {
+                return value
+            }
+
+            return .twitter
+        }
+        set { self[.keyboardType] = newValue.rawValue }
     }
 
     var animateHeaders: Bool {
@@ -210,6 +229,7 @@ private extension AppPreferences {
         case requireDoubleTapToReblog
         case requireDoubleTapToFavorite
         case animateAvatars
+        case keyboardType
         case animateHeaders
         case animateCustomEmojis
         case autoplayGIFs

--- a/Views/SwiftUI/PreferencesView.swift
+++ b/Views/SwiftUI/PreferencesView.swift
@@ -101,6 +101,12 @@ struct PreferencesView: View {
                             Text(option.localizedStringKey).tag(option)
                         }
                     }
+                    Picker("preferences.keyboard-type",
+                           selection: $identityContext.appPreferences.keyboardType) {
+                        ForEach(AppPreferences.KeyboardType.allCases) { option in
+                            Text(option.localizedStringKey).tag(option)
+                        }
+                    }
                     Toggle("preferences.show-reblog-and-favorite-counts",
                            isOn: $identityContext.appPreferences.showReblogAndFavoriteCounts)
                     Toggle("preferences.require-double-tap-to-reblog",
@@ -191,6 +197,17 @@ extension AppPreferences.AnimateAvatars {
             return "preferences.media.avatars.animate.profiles"
         case .never:
             return "preferences.media.avatars.animate.never"
+        }
+    }
+}
+
+extension AppPreferences.KeyboardType {
+    var localizedStringKey: LocalizedStringKey {
+        switch self {
+        case .twitter:
+            return "preferences.keyboard-type.twitter"
+        case .defaultText:
+            return "preferences.keyboard-type.default-text"
         }
     }
 }

--- a/Views/UIKit/CompositionView.swift
+++ b/Views/UIKit/CompositionView.swift
@@ -107,7 +107,9 @@ private extension CompositionView {
             autocompleteQueryPublisher: viewModel.$autocompleteQuery.eraseToAnyPublisher())
 
         stackView.addArrangedSubview(textView)
-        textView.keyboardType = .twitter
+        textView.keyboardType = parentViewModel.identityContext.appPreferences.keyboardType == .twitter
+            ? .twitter
+            : .default
         textView.isScrollEnabled = false
         textView.adjustsFontForContentSizeCategory = true
         textView.font = textViewFont


### PR DESCRIPTION
### Summary

This fixes #76 by implementing the proposed solution to make the keyboard type configurable in the app's preferences.

### Other Information

- [x] I have signed [Metabolist's Contributor License Agreement](https://metabolist.org/cla)
- [ ] The proposed changes are limited in scope to fixing bugs, or I have discussed larger scope changes via email
